### PR TITLE
Support 8-bit numbers in RGB

### DIFF
--- a/ColorAssetCatalog/Classes/ColorAssetCatalog.swift
+++ b/ColorAssetCatalog/Classes/ColorAssetCatalog.swift
@@ -137,20 +137,33 @@ extension ColorAsset.Color {
 
         private func decodeCGFloat(for key: CodingKeys, in container: KeyedDecodingContainer<CodingKeys>) throws -> CGFloat {
             // Support three formats: float (0-1), integer (0-255) and 8 bit hex.
-            let base: CGFloat
-            let valueString = try container.decode(String.self, forKey: key)
-            if valueString.contains(".") {
-                base = 1.0
-            } else {
-                // Otherwise has a prefix "0x" or is an integer.
-                base = 255
-            }
+            do {
+                let base: CGFloat
+                let valueString = try container.decode(String.self, forKey: key)
+                // Support three formats: float (0-1), integer (0-255) and 8 bit hex.
+                if valueString.contains(".") {
+                    base = 1.0
+                } else {
+                    // Otherwise has a prefix "0x" or is an integer.
+                    base = 255
+                }
 
-            guard let double = Double(valueString) else {
-                throw DecodingError.typeMismatch(CGFloat.self, DecodingError.Context(codingPath: [key], debugDescription: valueString))
-            }
+                guard let double = Double(valueString) else {
+                    throw DecodingError.typeMismatch(CGFloat.self, DecodingError.Context(codingPath: [key], debugDescription: valueString))
+                }
 
-            return CGFloat(double) / base
+                return CGFloat(double) / base
+
+            } catch {
+                // Fallback to numeric values.
+                let value: CGFloat
+                do {
+                    value = CGFloat(try container.decode(Int.self, forKey: key))
+                } catch {
+                    value = CGFloat(try container.decode(CGFloat.self, forKey: key))
+                }
+                return value / CGFloat(value > 1 ? 255 : 1)
+            }
         }
     }
 }

--- a/ColorAssetCatalog/Classes/ColorAssetCatalog.swift
+++ b/ColorAssetCatalog/Classes/ColorAssetCatalog.swift
@@ -136,15 +136,21 @@ extension ColorAsset.Color {
         }
 
         private func decodeCGFloat(for key: CodingKeys, in container: KeyedDecodingContainer<CodingKeys>) throws -> CGFloat {
-            do {
-                return try container.decode(CGFloat.self, forKey: key)
-            } catch {
-                let string = try container.decode(String.self, forKey: key)
-                guard let double = Double(string) else {
-                    throw DecodingError.typeMismatch(CGFloat.self, DecodingError.Context(codingPath: [key], debugDescription: string))
-                }
-                return CGFloat(double)
+            // Support three formats: float (0-1), integer (0-255) and 8 bit hex.
+            let base: CGFloat
+            let valueString = try container.decode(String.self, forKey: key)
+            if valueString.contains(".") {
+                base = 1.0
+            } else {
+                // Otherwise has a prefix "0x" or is an integer.
+                base = 255
             }
+
+            guard let double = Double(valueString) else {
+                throw DecodingError.typeMismatch(CGFloat.self, DecodingError.Context(codingPath: [key], debugDescription: valueString))
+            }
+
+            return CGFloat(double) / base
         }
     }
 }

--- a/Example/ColorAssetCatalog/Colors.xcassets/8-bit Hex.colorset/Contents.json
+++ b/Example/ColorAssetCatalog/Colors.xcassets/8-bit Hex.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0xFF",
+          "alpha" : "1.000",
+          "blue" : "0x9F",
+          "green" : "0x2F"
+        }
+      }
+    }
+  ]
+}

--- a/Example/ColorAssetCatalog/Colors.xcassets/8-bit.colorset/Contents.json
+++ b/Example/ColorAssetCatalog/Colors.xcassets/8-bit.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "red" : "1",
+          "alpha" : "1.000",
+          "blue" : "255",
+          "green" : "180"
+        }
+      }
+    }
+  ]
+}

--- a/Example/ColorAssetCatalog/DemoViewController.swift
+++ b/Example/ColorAssetCatalog/DemoViewController.swift
@@ -12,7 +12,7 @@ import ColorAssetCatalog
 class DemoViewController: UIViewController {
     @IBOutlet private var mainLabel: UILabel!
 
-    let colorNames = ["universal", "device-specific", "p3", "missing", "string-components"]
+    let colorNames = ["universal", "device-specific", "p3", "missing", "string-components", "8-bit", "8-bit Hex"]
 
     var currentColorName: String? {
         didSet {


### PR DESCRIPTION
Fix for #7. The number formatting is now checked before parsing. Alpha didn't need this, it's always a floating point value, but it doesn't hurt to check that too.